### PR TITLE
Simplify attestations into one action + output summary

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -76,8 +76,8 @@ jobs:
         #cat "$GITHUB_STEP_SUMMARY"
         #echo "${{join(steps.genprovenance.outputs.*, '\n')}}"
         #find ${{runner.temp}}
-        echo "${{ steps.job-summary.outputs.job-summary }}" > attestation.html
-        cat attestation.html
+        echo "${{ steps.job-summary.outputs.job-summary }}" 
+        echo "${{ steps.job-summary.outputs.html-file }}"
     - uses: actions/upload-artifact@v4
       with:
         name: sboms
@@ -87,6 +87,6 @@ jobs:
               ${{ env.cdxBASENAME }}.json
               spdx-${{ env.BASENAME }}-sbomqs.txt
               attestation.jsonl
-              attestation.html
+              ${{ steps.job-summary.outputs.html-file }}
 
         

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -71,8 +71,7 @@ jobs:
         cp ${{ steps.genprovenance.outputs.bundle-path }} attestation.jsonl
         cat "$GITHUB_STEP_SUMMARY"
         echo "${{join(steps.genprovenance.outputs.*, '\n')}}"
-        find /_temp/_runner_file_commands/
-        find ${{runner.temp}}/_runner_file_commands/
+        find ${{runner.temp}}
     - uses: actions/upload-artifact@v4
       with:
         name: sboms

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -69,15 +69,12 @@ jobs:
       id: job-summary
       with:
           create-pdf: false
+          create-pdf-artifact: false
     - name: Copy Attestation Manfiest to output
       run: |
         echo "Attestation Bundle Path: ${{ steps.genprovenance.outputs.bundle-path }}" 
         cp ${{ steps.genprovenance.outputs.bundle-path }} attestation.jsonl
-        #cat "$GITHUB_STEP_SUMMARY"
-        #echo "${{join(steps.genprovenance.outputs.*, '\n')}}"
-        #find ${{runner.temp}}
-        echo "${{ steps.job-summary.outputs.job-summary }}" 
-        echo "${{ steps.job-summary.outputs.html-file }}"
+        cp "${{ steps.job-summary.outputs.html-file }}" attestation.html
     - uses: actions/upload-artifact@v4
       with:
         name: sboms
@@ -87,6 +84,6 @@ jobs:
               ${{ env.cdxBASENAME }}.json
               spdx-${{ env.BASENAME }}-sbomqs.txt
               attestation.jsonl
-              ${{ steps.job-summary.outputs.html-file }}
+              attestation.html
 
         

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -67,10 +67,10 @@ jobs:
           spdx-${{ env.BASENAME }}-sbomqs.txt
     - name: Copy Attestation Manfiest to output
       run: |
-        echo "Attestation Bundle Path: ${{ steps.genprovenance.outputs.bundle-path }}" >> BundlePath.txt
-        cat BundlePath.txt
-        cp ${{env.GITHUB_STEP_SUMMARY}} AttestationSummary.html
-        cat AttestationSummary.html
+        echo "Attestation Bundle Path: ${{ steps.genprovenance.outputs.bundle-path }}" 
+        cat ${{ steps.genprovenance.outputs.bundle-path }}
+        # cp ${{env.GITHUB_STEP_SUMMARY}} AttestationSummary.html
+        # cat AttestationSummary.html
     - uses: actions/upload-artifact@v4
       with:
         name: sboms
@@ -79,7 +79,7 @@ jobs:
               ${{ env.cdxBASENAME }}.xml
               ${{ env.cdxBASENAME }}.json
               spdx-${{ env.BASENAME }}-sbomqs.txt
-              BundlePath.txt
-              AttestationSummary.html
+              ${{ steps.genprovenance.outputs.bundle-path }}
+              # AttestationSummary.html
 
         

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -68,8 +68,11 @@ jobs:
     - name: Copy Attestation Manfiest to output
       run: |
         echo "Attestation Bundle Path: ${{ steps.genprovenance.outputs.bundle-path }}" 
+        cp ${{ steps.genprovenance.outputs.bundle-path }} attestation.jsonl
         cat "$GITHUB_STEP_SUMMARY"
         echo "${{join(steps.genprovenance.outputs.*, '\n')}}"
+        find /_temp/_runner_file_commands/
+        find ${{runner.temp}}/_runner_file_commands/
     - uses: actions/upload-artifact@v4
       with:
         name: sboms
@@ -78,7 +81,7 @@ jobs:
               ${{ env.cdxBASENAME }}.xml
               ${{ env.cdxBASENAME }}.json
               spdx-${{ env.BASENAME }}-sbomqs.txt
-              ${{ steps.genprovenance.outputs.bundle-path }}
+              attestation.jsonl
               $GITHUB_STEP_SUMMARY
 
         

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -69,8 +69,9 @@ jobs:
       run: |
         echo "Attestation Bundle Path: ${{ steps.genprovenance.outputs.bundle-path }}" 
         cat ${{ steps.genprovenance.outputs.bundle-path }}
-        # cp ${{env.GITHUB_STEP_SUMMARY}} AttestationSummary.html
-        # cat AttestationSummary.html
+        cat "$GITHUB_STEP_SUMMARY"
+        cp "$GITHUB_STEP_SUMMARY" AttestationSummary.html
+        cat AttestationSummary.html
     - uses: actions/upload-artifact@v4
       with:
         name: sboms

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -24,10 +24,6 @@ jobs:
     - name: Rename SBOM File to spdx- prefix
       run: | 
         mv ${{ steps.gensbom.outputs.fileName }}  spdx-${{ steps.gensbom.outputs.fileName }}  
-    - name: Generate artifact attestation - SPDX JSON
-      uses: actions/attest-build-provenance@v1
-      with:          
-        subject-path: spdx-${{ steps.gensbom.outputs.fileName }}    
     - name: Download CycloneDX CLI
       run: |
           LATEST_RELEASE=$(curl -s https://api.github.com/repos/CycloneDX/cyclonedx-cli/releases/latest | jq -r '.tag_name')
@@ -47,14 +43,6 @@ jobs:
           ./cyclonedx convert --input-file /tmp/spdx.json  --output-file "${cdxBASENAME}.json" --input-format spdxjson --output-format json
           ./cyclonedx convert --input-file /tmp/spdx.json  --output-file "${cdxBASENAME}.xml" --input-format spdxjson --output-format xml
           ls cdx*
-    - name: Generate artifact attestation - CDX JSON
-      uses: actions/attest-build-provenance@v1
-      with:          
-        subject-path: ${{ env.cdxBASENAME }}.json
-    - name: Generate artifact attestation - CDX XML
-      uses: actions/attest-build-provenance@v1
-      with:          
-        subject-path: ${{ env.cdxBASENAME }}.xml
     - name: sbom quality score install (interlynk-io/sbomqs)
       run: |
         # go version
@@ -68,10 +56,21 @@ jobs:
         echo "" >> spdx-${{ env.BASENAME }}-sbomqs.txt
         sbomqs share spdx-${{ steps.gensbom.outputs.fileName }}  >> spdx-${{ env.BASENAME }}-sbomqs.txt
         cat spdx-${{ env.BASENAME }}-sbomqs.txt
-    - name: Generate artifact attestation - SBOMQ
+    - name: Generate artifact attestations
+      id: genprovenance
       uses: actions/attest-build-provenance@v1
       with:          
-        subject-path: spdx-${{ env.BASENAME }}-sbomqs.txt
+        subject-path: |
+          spdx-${{ steps.gensbom.outputs.fileName }}
+          ${{ env.cdxBASENAME }}.xml
+          ${{ env.cdxBASENAME }}.json
+          spdx-${{ env.BASENAME }}-sbomqs.txt
+    - name: Copy Attestation Manfiest to output
+      run: |
+        echo "Attestation Bundle Path: ${{ steps.genprovenance.outputs.bundle-path }}" >> BundlePath.txt
+        cat BundlePath.txt
+        cp ${{env.GITHUB_STEP_SUMMARY}} AttestationSummary.html
+        cat AttestationSummary.html
     - uses: actions/upload-artifact@v4
       with:
         name: sboms
@@ -80,5 +79,7 @@ jobs:
               ${{ env.cdxBASENAME }}.xml
               ${{ env.cdxBASENAME }}.json
               spdx-${{ env.BASENAME }}-sbomqs.txt
+              BundlePath.txt
+              AttestationSummary.html
 
         

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -68,10 +68,8 @@ jobs:
     - name: Copy Attestation Manfiest to output
       run: |
         echo "Attestation Bundle Path: ${{ steps.genprovenance.outputs.bundle-path }}" 
-        cat ${{ steps.genprovenance.outputs.bundle-path }}
         cat "$GITHUB_STEP_SUMMARY"
-        cp "$GITHUB_STEP_SUMMARY" AttestationSummary.html
-        cat AttestationSummary.html
+        echo "${{join(steps.genprovenance.outputs.*, '\n')}}"
     - uses: actions/upload-artifact@v4
       with:
         name: sboms
@@ -81,6 +79,6 @@ jobs:
               ${{ env.cdxBASENAME }}.json
               spdx-${{ env.BASENAME }}-sbomqs.txt
               ${{ steps.genprovenance.outputs.bundle-path }}
-              # AttestationSummary.html
+              $GITHUB_STEP_SUMMARY
 
         

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -65,13 +65,19 @@ jobs:
           ${{ env.cdxBASENAME }}.xml
           ${{ env.cdxBASENAME }}.json
           spdx-${{ env.BASENAME }}-sbomqs.txt
+    - uses: austenstone/job-summary-to-pdf@main
+      id: job-summary
+      with:
+          create-pdf: false
     - name: Copy Attestation Manfiest to output
       run: |
         echo "Attestation Bundle Path: ${{ steps.genprovenance.outputs.bundle-path }}" 
         cp ${{ steps.genprovenance.outputs.bundle-path }} attestation.jsonl
-        cat "$GITHUB_STEP_SUMMARY"
-        echo "${{join(steps.genprovenance.outputs.*, '\n')}}"
-        find ${{runner.temp}}
+        #cat "$GITHUB_STEP_SUMMARY"
+        #echo "${{join(steps.genprovenance.outputs.*, '\n')}}"
+        #find ${{runner.temp}}
+        echo "${{ steps.job-summary.outputs.job-summary }}" > attestation.html
+        cat attestation.html
     - uses: actions/upload-artifact@v4
       with:
         name: sboms
@@ -81,6 +87,6 @@ jobs:
               ${{ env.cdxBASENAME }}.json
               spdx-${{ env.BASENAME }}-sbomqs.txt
               attestation.jsonl
-              $GITHUB_STEP_SUMMARY
+              attestation.html
 
         


### PR DESCRIPTION
### Workflow Improvements:

* **Consolidated Artifact Attestation Steps**: The individual steps for generating artifact attestations for SPDX JSON, CDX JSON, CDX XML, and SBOMQ have been merged into a single step. This new step, `Generate artifact attestations`, now handles all the attestation files together. (`.github/workflows/sbom.yml`)

### New Additions:

* **Job Summary to PDF**: Added a step to use `austenstone/job-summary-to-pdf@main` for creating a job summary in HTML format, although the PDF creation is disabled. (`.github/workflows/sbom.yml`)
* **Copy Attestation Manifest to Output**: Added a step to copy the attestation manifest to the output directory, including both the JSONL and HTML files. (`.github/workflows/sbom.yml`)

### Removals:

* **Removed Individual Attestation Steps**: The steps for generating individual artifact attestations for SPDX JSON, CDX JSON, CDX XML, and SBOMQ have been removed. (`.github/workflows/sbom.yml`) [[1]](diffhunk://#diff-a3f913c1fa8c348e5409e1fe8daa2933204d77ab0f67cb99d67c84a2035ca875L27-L30) [[2]](diffhunk://#diff-a3f913c1fa8c348e5409e1fe8daa2933204d77ab0f67cb99d67c84a2035ca875L50-L57) [[3]](diffhunk://#diff-a3f913c1fa8c348e5409e1fe8daa2933204d77ab0f67cb99d67c84a2035ca875L71-R77)

### Artifact Upload:

* **Updated Artifact Upload**: The upload artifact step now includes the newly generated attestation files (`attestation.jsonl` and `attestation.html`). (`.github/workflows/sbom.yml`)